### PR TITLE
Updated open in intellij button to work with flatpaks

### DIFF
--- a/src/main/kotlin/gdx/liftoff/views/dialogs/GenerationPrompt.kt
+++ b/src/main/kotlin/gdx/liftoff/views/dialogs/GenerationPrompt.kt
@@ -20,6 +20,7 @@ import gdx.liftoff.data.project.ProjectLogger
 import gdx.liftoff.views.MainView
 import gdx.liftoff.views.widgets.ScrollableTextArea
 import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.properties.Delegates
 
 /**
  * Displayed after generation request was sent.
@@ -28,6 +29,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 @Suppress("unused") // Referenced via reflection.
 class GenerationPrompt : ViewDialogShower, ProjectLogger, ActionContainer {
   private lateinit var intellijPath: String
+  private var intellijIsFlatpak by Delegates.notNull<Boolean>()
 
   @Inject private val locale: LocaleService = inject()
 
@@ -80,12 +82,38 @@ class GenerationPrompt : ViewDialogShower, ProjectLogger, ActionContainer {
       }
 
       intellijPath = process.inputStream.bufferedReader().readLine()
+      intellijIsFlatpak = false
+
       ideaButton.isDisabled = false
     } catch (e: Exception) {
       Tooltip.Builder("Couldn't find IntelliJ in PATH.\nMake sure that you have JetBrains Toolbox and \"Generate shell scripts\" checked in its settings.").target(ideaButton).build()
       ideaButton.isDisabled = true
     }
 //    }
+
+    if (ideaButton.isDisabled && UIUtils.isLinux) {
+      try {
+        val findFlatpakIntellij = arrayListOf("flatpak", "list", "--app", "--columns=application")
+
+        val process = ProcessBuilder(findFlatpakIntellij).start()
+        if (process.waitFor() != 0) {
+          throw Exception("Flatpak Intellij not found")
+        }
+
+        val ids = arrayListOf("com.jetbrains.IntelliJ-IDEA-Ultimate", "com.jetbrains.IntelliJ-IDEA-Community")
+        val output = process.inputStream.bufferedReader().readLines().stream().filter { ids.contains(it) }.findFirst().orElse(null)
+        if (output == null)
+          throw Exception("Flatpak Intellij not installed")
+
+        intellijPath = output
+        intellijIsFlatpak = true
+
+        ideaButton.isDisabled = false
+      } catch (e: Exception) {
+        Tooltip.Builder("Couldn't find IntelliJ in PATH or as a flatpak.\nMake sure that you have JetBrains Toolbox and \"Generate shell scripts\" checked in its settings.").target(ideaButton).build()
+        ideaButton.isDisabled = true
+      }
+    }
   }
 
   override fun logNls(bundleLine: String) = log(locale.i18nBundle.get(bundleLine))
@@ -114,6 +142,10 @@ class GenerationPrompt : ViewDialogShower, ProjectLogger, ActionContainer {
 
   @LmlAction("openIdea")
   fun openIdea() {
-    ProcessBuilder(intellijPath, ".").directory(mainView.getDestination().file()).start()
+    if (intellijIsFlatpak) {
+      ProcessBuilder(arrayListOf("flatpak", "run", intellijPath, ".")).directory(mainView.getDestination().file()).start()
+    } else {
+      ProcessBuilder(intellijPath, ".").directory(mainView.getDestination().file()).start()
+    }
   }
 }

--- a/src/main/kotlin/gdx/liftoff/views/dialogs/GenerationPrompt.kt
+++ b/src/main/kotlin/gdx/liftoff/views/dialogs/GenerationPrompt.kt
@@ -102,8 +102,9 @@ class GenerationPrompt : ViewDialogShower, ProjectLogger, ActionContainer {
 
         val ids = arrayListOf("com.jetbrains.IntelliJ-IDEA-Ultimate", "com.jetbrains.IntelliJ-IDEA-Community")
         val output = process.inputStream.bufferedReader().readLines().stream().filter { ids.contains(it) }.findFirst().orElse(null)
-        if (output == null)
+        if (output == null) {
           throw Exception("Flatpak Intellij not installed")
+        }
 
         intellijPath = output
         intellijIsFlatpak = true


### PR DESCRIPTION
Hey!

I've switched over to linux as my main os for programming related things a bit ago.

Since flatpaks are cool I'm using those for intellij too, however the open in intellij button didn't account for flatpak installations.

This PR makes the button work with flatpaks.

![image](https://github.com/libgdx/gdx-liftoff/assets/11274700/2d0616d9-bacb-4533-b62e-b8ce1b11430f)
![image](https://github.com/libgdx/gdx-liftoff/assets/11274700/9d65919c-3ef0-4602-b440-10fae26d3b30)
![image](https://github.com/libgdx/gdx-liftoff/assets/11274700/7c0ac928-075d-4d71-bd2a-4ad5590f883b)
