### PR TITLE
Added option to close dialogs with escape or enter

### DIFF
--- a/src/main/java/gdx/liftoff/ui/dialogs/ExtensionsDialog.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/ExtensionsDialog.java
@@ -1,6 +1,7 @@
 package gdx.liftoff.ui.dialogs;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Event;
@@ -124,6 +125,8 @@ public class ExtensionsDialog extends PopTable {
         contentTable.add(textButton).prefWidth(140).spaceTop(SPACE_LARGE);
         addHandListener(textButton);
         onChange(textButton, this::hide);
+        key(Keys.ENTER, this::hide);
+        key(Keys.ESCAPE, this::hide);
     }
 
     /**

--- a/src/main/java/gdx/liftoff/ui/dialogs/GradleDialog.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/GradleDialog.java
@@ -1,5 +1,6 @@
 package gdx.liftoff.ui.dialogs;
 
+import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.ui.Window.WindowStyle;
 import com.badlogic.gdx.utils.Scaling;
@@ -77,6 +78,8 @@ public class GradleDialog extends PopTable {
         contentTable.add(textButton).prefWidth(140).spaceTop(SPACE_LARGE);
         addHandListener(textButton);
         onChange(textButton, this::hide);
+        key(Keys.ENTER, this::hide);
+        key(Keys.ESCAPE, this::hide);
     }
 
     public static PopTable show(boolean fullscreen) {

--- a/src/main/java/gdx/liftoff/ui/dialogs/LanguagesDialog.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/LanguagesDialog.java
@@ -1,6 +1,7 @@
 package gdx.liftoff.ui.dialogs;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.scenes.scene2d.Event;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.ui.Window.WindowStyle;
@@ -127,6 +128,8 @@ public class LanguagesDialog extends PopTable {
         contentTable.add(textButton).prefWidth(140).spaceTop(SPACE_LARGE);
         addHandListener(textButton);
         onChange(textButton, this::hide);
+        key(Keys.ENTER, this::hide);
+        key(Keys.ESCAPE, this::hide);
     }
 
     /**

--- a/src/main/java/gdx/liftoff/ui/dialogs/PlatformsDialog.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/PlatformsDialog.java
@@ -1,5 +1,6 @@
 package gdx.liftoff.ui.dialogs;
 
+import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.scenes.scene2d.Event;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
@@ -118,6 +119,8 @@ public class PlatformsDialog extends PopTable {
         contentTable.add(textButton).prefWidth(140).spaceTop(SPACE_LARGE);
         addHandListener(textButton);
         onChange(textButton, this::hide);
+        key(Keys.ENTER, this::hide);
+        key(Keys.ESCAPE, this::hide);
     }
 
     /**

--- a/src/main/java/gdx/liftoff/ui/dialogs/TemplatesDialog.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/TemplatesDialog.java
@@ -1,6 +1,7 @@
 package gdx.liftoff.ui.dialogs;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.scenes.scene2d.*;
@@ -149,6 +150,8 @@ public class TemplatesDialog extends PopTable {
         contentTable.add(textButton).prefWidth(140).spaceTop(SPACE_LARGE);
         addHandListener(textButton);
         onChange(textButton, this::hide);
+        key(Keys.ENTER, this::hide);
+        key(Keys.ESCAPE, this::hide);
     }
 
     private void addTemplate(Table table, ButtonGroup<CheckBox> buttonGroup, String templateName, String description) {


### PR DESCRIPTION
I added the option to close dialogs (platforms, languages, extensions, and gradle commands) with escape or enter. This is largely for power users who are accustomed to using these keys to dismiss dialogs in their OS.