### PR TITLE
Reset button tweaks

### DIFF
--- a/src/main/java/gdx/liftoff/ui/dialogs/ConfirmResetUserData.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/ConfirmResetUserData.java
@@ -12,6 +12,7 @@ import com.ray3k.stripe.PopTable;
 
 import static com.badlogic.gdx.scenes.scene2d.actions.Actions.*;
 import static gdx.liftoff.Main.*;
+import static gdx.liftoff.ui.dialogs.FullscreenCompleteDialog.*;
 import static gdx.liftoff.ui.dialogs.FullscreenDialog.*;
 
 public class ConfirmResetUserData extends PopTable {
@@ -48,13 +49,18 @@ public class ConfirmResetUserData extends PopTable {
         hide();
         resetUserData();
 
-        if (fullscreenDialog == null) {
+        if (fullscreenDialog != null) {
+            Action action = sequence(alpha(0), Actions.run(() -> fullscreenDialog.populate()), fadeIn(.2f));
+            fullscreenDialog.addAction(action);
+        } else if (fullscreenCompleteDialog != null) {
+            fullscreenCompleteDialog.hide();
+            FullscreenDialog.show();
+        } else if (root.getCurrentTable() == root.completeTable) {
+            root.transitionTable(root.landingTable,true);
+        } else {
             root.getCurrentTable().populate();
             root.getCurrentTable().setColor(1, 1, 1, 0);
             Gdx.app.postRunnable(() -> root.fadeInTable());
-        } else {
-            Action action = sequence(alpha(0), Actions.run(() -> fullscreenDialog.populate()), fadeIn(.2f));
-            fullscreenDialog.addAction(action);
         }
     }
 

--- a/src/main/java/gdx/liftoff/ui/dialogs/FullscreenCompleteDialog.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/FullscreenCompleteDialog.java
@@ -2,10 +2,12 @@ package gdx.liftoff.ui.dialogs;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
+import com.badlogic.gdx.scenes.scene2d.ui.Button;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.Window.WindowStyle;
+import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.Scaling;
 import com.ray3k.stripe.CollapsibleGroup;
 import com.ray3k.stripe.CollapsibleGroup.CollapseType;
@@ -56,6 +58,14 @@ public class FullscreenCompleteDialog extends PopTable {
         //generating panel is displayed first and is alternated with the complete panel upon completion of the animation
         GeneratingPanel generatingPanel = new GeneratingPanel(true);
 
+        //reset button
+        Button button = new Button(skin, "reload");
+        contentTable.add(button).expandX().right();
+        addTooltip(button, Align.left, prop.getProperty("reset"));
+        addHandListener(button);
+        onChange(button, ConfirmResetUserData::showDialog);
+
+        contentTable.row();
         Table table = new Table();
         contentTable.stack(generatingPanel, table).grow();
 


### PR DESCRIPTION
The reset button has been added to the FullscreenCompleteDialog. It also behaves better on the complete screen. It will take the user back to the landing page now instead of showing the loading screen again.