### PR TITLE
Update warning when deleting the folder contents.

### DIFF
--- a/src/main/java/gdx/liftoff/ui/dialogs/ConfirmDeleteProjectFolder.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/ConfirmDeleteProjectFolder.java
@@ -12,6 +12,7 @@ import com.ray3k.stripe.PopTable;
 import gdx.liftoff.ui.UserData;
 
 import static gdx.liftoff.Main.*;
+import static gdx.liftoff.ui.dialogs.FullscreenDialog.*;
 
 public class ConfirmDeleteProjectFolder extends PopTable {
     public ConfirmDeleteProjectFolder() {
@@ -54,6 +55,8 @@ public class ConfirmDeleteProjectFolder extends PopTable {
         for (FileHandle child : fileHandle.list()) {
             child.deleteDirectory();
         }
+        Gdx.app.postRunnable(() -> root.settingsTable.updateError());
+        if (fullscreenDialog != null) fullscreenDialog.updatePathsError();
         hide();
     }
 

--- a/src/main/java/gdx/liftoff/ui/dialogs/FullscreenDialog.java
+++ b/src/main/java/gdx/liftoff/ui/dialogs/FullscreenDialog.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.ui.Window.WindowStyle;
 import com.badlogic.gdx.utils.Align;
+import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Scaling;
 import com.ray3k.stripe.CollapsibleGroup;
 import com.ray3k.stripe.CollapsibleGroup.CollapseType;
@@ -13,6 +14,8 @@ import com.ray3k.stripe.ScaleContainer;
 import gdx.liftoff.Main;
 import gdx.liftoff.ui.LogoWidget;
 import gdx.liftoff.ui.panels.*;
+
+import java.util.ArrayList;
 
 import static com.badlogic.gdx.scenes.scene2d.actions.Actions.*;
 import static gdx.liftoff.Main.*;
@@ -25,6 +28,7 @@ public class FullscreenDialog extends PopTable {
     public static FullscreenDialog fullscreenDialog;
     private TextButton generateButton;
     private Table versionTable;
+    private ArrayList<PathsPanel> pathsPanel = new ArrayList<>();
 
     public FullscreenDialog() {
         super(skin.get("fullscreen", WindowStyle.class));
@@ -122,8 +126,9 @@ public class FullscreenDialog extends PopTable {
 
         //paths panel
         subTable.row();
-        PathsPanel pathsPanel = new PathsPanel(true);
-        subTable.add(pathsPanel).minWidth(450);
+        PathsPanel pathPanel = new PathsPanel(true);
+        subTable.add(pathPanel).minWidth(450);
+        pathsPanel.add(pathPanel);
 
         contentTable.row();
         table = new Table();
@@ -172,6 +177,10 @@ public class FullscreenDialog extends PopTable {
             addTooltip(updateButton, Align.top, prop.getProperty("updateTip"));
             onChange(updateButton, () -> Gdx.net.openURI(prop.getProperty("updateUrl")));
         }
+    }
+
+    public void updatePathsError() {
+        pathsPanel.forEach(PathsPanel::updateError);
     }
 
     public static void show() {

--- a/src/main/java/gdx/liftoff/ui/liftofftables/SettingsTable.java
+++ b/src/main/java/gdx/liftoff/ui/liftofftables/SettingsTable.java
@@ -17,6 +17,7 @@ import static gdx.liftoff.Main.*;
 public class SettingsTable extends LiftoffTable {
     private SettingsPanel settingsPanel;
     private TextButton generateButton;
+    private PathsPanel pathsPanel;
 
     public SettingsTable() {
         populate();
@@ -43,7 +44,7 @@ public class SettingsTable extends LiftoffTable {
 
         //paths panel
         scrollTable.row();
-        PathsPanel pathsPanel = new PathsPanel(false);
+        pathsPanel = new PathsPanel(false);
         scrollTable.add(pathsPanel).growX().spaceTop(SPACE_HUGE);
 
         row();
@@ -86,4 +87,7 @@ public class SettingsTable extends LiftoffTable {
         generateButton.setDisabled(!validateUserData());
     }
 
+    public void updateError() {
+        pathsPanel.updateError();
+    }
 }

--- a/src/main/java/gdx/liftoff/ui/panels/PathsPanel.java
+++ b/src/main/java/gdx/liftoff/ui/panels/PathsPanel.java
@@ -68,12 +68,14 @@ public class PathsPanel extends Table implements Panel {
             });
         });
 
+        //select folder button
         Button button = new Button(skin, "folder");
         add(button);
         addHandListener(button);
         addTooltip(button, Align.top, 0, prop.getProperty("destinationTip"));
         onChange(button, () -> projectFieldButton.setChecked(!projectFieldButton.isChecked()));
 
+        //delete folder contents button
         deleteProjectPathButton = new Button(skin, "delete-folder");
         add(deleteProjectPathButton);
         addHandListener(deleteProjectPathButton);
@@ -136,7 +138,7 @@ public class PathsPanel extends Table implements Panel {
         deleteProjectPathButton.setDisabled(UserData.projectPath == null || UserData.projectPath.isEmpty());
     }
 
-    private void updateError() {
+    public void updateError() {
         if (UserData.projectPath == null || UserData.projectPath.isEmpty()) {
             errorLabel.setText(prop.getProperty("nullDirectory"));
             return;


### PR DESCRIPTION
When the user clicks the delete folder contents button on the settings screen, it now removes the warning that the folder is going to be overwritten.