### PR TITLE
Update generate button when android path is selected.

### DIFF
--- a/src/main/java/gdx/liftoff/ui/panels/PathsPanel.java
+++ b/src/main/java/gdx/liftoff/ui/panels/PathsPanel.java
@@ -114,6 +114,9 @@ public class PathsPanel extends Table implements Panel {
                             pref.putString("AndroidSdk", path);
                             pref.flush();
                             updateError();
+                            if (FullscreenDialog.fullscreenDialog != null)
+                                FullscreenDialog.fullscreenDialog.updateGenerateButtons();
+                            if (root.settingsTable != null) root.settingsTable.updateGenerateButton();
                         }
                     }
                 });


### PR DESCRIPTION
This fixes the problem with the generate button not being updated when the user selects an android sdk path.