### PR TITLE
Fix game version in construo distribution zip

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/files/gradle/RootGradleFile.kt
+++ b/src/main/kotlin/gdx/liftoff/data/files/gradle/RootGradleFile.kt
@@ -84,7 +84,7 @@ ${plugins.joinToString(separator = "\n") { "  apply plugin: '$it'" }}
 }
 
 subprojects {
-  version = '${project.advanced.version}'
+  version = '${'$'}gameVersion'
   ext.appName = '${project.basic.name}'
   repositories {
     mavenCentral()

--- a/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl3.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Lwjgl3.kt
@@ -214,7 +214,7 @@ construo {
     // human-readable name, used for example in the `.app` name for macOS
     humanName.set(appName)
     // Optional, defaults to project version
-    version.set("0.0.0")
+    version.set('${'$'}gameVersion')
 
     targets.configure {
       create("linuxX64", Target.Linux) {

--- a/src/main/kotlin/gdx/liftoff/data/project/Project.kt
+++ b/src/main/kotlin/gdx/liftoff/data/project/Project.kt
@@ -144,6 +144,7 @@ class Project(
   private fun saveProperties() {
     // Adding libGDX version property:
     properties["gdxVersion"] = advanced.gdxVersion
+    properties["gameVersion"] = advanced.version
     PropertiesFile(properties).save(basic.destination)
   }
 


### PR DESCRIPTION
Hey guys,

First of all: I love the new gdx liftoff! Thanks a lot for all the work!

Here is a small PR  to address a problem I encountered:
Packaging a generated project with the construo task packageWinX64 will result in a zip file containing a folder called "Name-0.0.0-winX64". The version will always be "0.0.0". I guess it should be the game version though.
This PR will fix this and still keep the game version in a single place. I don't know if the  naming of the variable "gameVersion" is so good, maybe you have a better idea?