### PR TITLE
add archive version to dist zip file name for HTML build

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/platforms/GWT.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/GWT.kt
@@ -355,6 +355,7 @@ ${if (project.hasPlatform(Shared.ID)) "    sourceSets.main.compileClasspath += f
 task distZip(type: Zip, dependsOn: dist){
   //// This uses the output of the dist task, which removes the superdev button from index.html .
   from(outputPath)
+  archiveVersion = projectVersion
   archiveBaseName.set("${'$'}{appName}-dist")
   //// The result will be in html/build/ with a name containing "-dist".
   destinationDirectory.set(file("build"))


### PR DESCRIPTION
Hi, this PR updates the zip file name to include the `projectVersion`. E.g, the file will now be named `game-dist-1.0.0.zip` instead of `game-dist-$projectVersion.zip`