### PR TITLE
Sort lines in assets.txt

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/files/gradle/RootGradleFile.kt
+++ b/src/main/kotlin/gdx/liftoff/data/files/gradle/RootGradleFile.kt
@@ -65,7 +65,7 @@ ${plugins.joinToString(separator = "\n") { "  apply plugin: '$it'" }}
     // iterate through all files inside that folder
     // convert it to a relative path
     // and append it to the file assets.txt
-    fileTree(assetsFolder).collect { assetsFolder.relativePath(it) }.each {
+    fileTree(assetsFolder).collect { assetsFolder.relativePath(it) }.sort().each {
       assetsFile.append(it + "\n")
     }
   }


### PR DESCRIPTION
First of all, sorry if this PR is crappy, I just made it very quickly while being tired in hopes it will help the LibGDX project.

I noticed adding `.sort()` fixed a really annoying problem of `assets/assets.txt` constantly changing order of lines if the project was developed on different machines.