### PR TITLE
Remove .ios from iOS backends packages

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/platforms/IOS.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/IOS.kt
@@ -43,7 +43,7 @@ class IOS : Platform {
         fileName = "robovm.properties",
         content = """app.version=${project.advanced.version.replace("[^0-9\\.]", "")}
 app.id=${project.basic.rootPackage}
-app.mainclass=${project.basic.rootPackage}.ios.IOSLauncher
+app.mainclass=${project.basic.rootPackage}.IOSLauncher
 app.executable=IOSLauncher
 app.build=1
 app.name=${project.basic.name}"""
@@ -213,7 +213,7 @@ apply plugin: 'robovm'
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 ext {
-  mainClassName = "${project.basic.rootPackage}.ios.IOSLauncher"
+  mainClassName = "${project.basic.rootPackage}.IOSLauncher"
 }
 
 launchIPhoneSimulator.dependsOn build

--- a/src/main/kotlin/gdx/liftoff/data/templates/KotlinTemplate.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/KotlinTemplate.kt
@@ -260,7 +260,7 @@ class StartupHelper private constructor() {
 
   override fun getIOSLauncherContent(project: Project): String = """@file:JvmName("IOSLauncher")
 
-package ${project.basic.rootPackage}.ios
+package ${project.basic.rootPackage}
 
 import org.robovm.apple.foundation.NSAutoreleasePool
 import org.robovm.apple.uikit.UIApplication

--- a/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/Template.kt
@@ -273,13 +273,13 @@ public class HeadlessLauncher {
     addSourceFile(
       project = project,
       platform = IOS.ID,
-      packageName = "${project.basic.rootPackage}.ios",
+      packageName = project.basic.rootPackage,
       fileName = "IOSLauncher.$launcherExtension",
       content = getIOSLauncherContent(project)
     )
   }
 
-  fun getIOSLauncherContent(project: Project): String = """package ${project.basic.rootPackage}.ios;
+  fun getIOSLauncherContent(project: Project): String = """package ${project.basic.rootPackage};
 
 import org.robovm.apple.foundation.NSAutoreleasePool;
 import org.robovm.apple.uikit.UIApplication;
@@ -307,13 +307,13 @@ public class IOSLauncher extends IOSApplication.Delegate {
     addSourceFile(
       project = project,
       platform = IOSMOE.ID,
-      packageName = "${project.basic.rootPackage}.ios",
+      packageName = project.basic.rootPackage,
       fileName = "IOSLauncher.$launcherExtension",
       content = getIOSMOELauncherContent(project)
     )
   }
 
-  fun getIOSMOELauncherContent(project: Project): String = """package ${project.basic.rootPackage}.ios;
+  fun getIOSMOELauncherContent(project: Project): String = """package ${project.basic.rootPackage};
 
 import apple.uikit.c.UIKit;
 import com.badlogic.gdx.backends.iosmoe.IOSApplication;

--- a/src/main/kotlin/gdx/liftoff/data/templates/unofficial/AutumnMvcBasicTemplate.kt
+++ b/src/main/kotlin/gdx/liftoff/data/templates/unofficial/AutumnMvcBasicTemplate.kt
@@ -219,7 +219,7 @@ public class HeadlessLauncher {
     }
 }"""
 
-  override fun getIOSLauncherContent(project: Project): String = """package ${project.basic.rootPackage}.ios;
+  override fun getIOSLauncherContent(project: Project): String = """package ${project.basic.rootPackage};
 
 import org.robovm.apple.foundation.NSAutoreleasePool;
 import org.robovm.apple.uikit.UIApplication;

--- a/src/main/resources/generator/ios-moe/xcode/ios-moe/Info.plist
+++ b/src/main/resources/generator/ios-moe/xcode/ios-moe/Info.plist
@@ -21,7 +21,7 @@
   <key>LSRequiresIPhoneOS</key>
   <true/>
   <key>MOE.Main.Class</key>
-  <string>%PACKAGE%.ios.IOSLauncher</string>
+  <string>%PACKAGE%.IOSLauncher</string>
   <key>UIApplicationExitsOnSuspend</key>
   <false/>
   <key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
Removed unnecessary ".ios" subpackage on iOS projects. It is unnecessary and makes dealing with provisioning profiles harder.

Have modified both RoboVM and MOE but have only tested RoboVM.