### PR TITLE
Improve GWT build

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/platforms/GWT.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/GWT.kt
@@ -65,6 +65,7 @@ class GWT : Platform {
 <module>
   <!-- Paths to source are relative to this file and separated by slashes ('/'). -->
   <source path="" />
+
   <!-- Reflection includes may be needed for your code or library code. Each value is separated by periods ('.'). -->
   <!-- You can include a full package by not including the name of a type at the end. -->
 ${(project.reflectedClasses + project.reflectedPackages).joinToString(
@@ -114,6 +115,10 @@ ${(project.reflectedClasses + project.reflectedPackages).joinToString(
 <module rename-to="html">
   <!-- Paths to source are relative to this file and separated by slashes ('/'). -->
   <source path="" />
+
+  <!-- Any resources placed under package public_html, relative to this file, will be copied verbatim into the final webapp folder. -->
+  <!-- This is where you can place your JavaScript, CSS and other resources for advanced JS integration. -->
+  <public path="public_html" />
 
   <!-- "Inherits" lines are how GWT knows where to look for code and configuration in other projects or libraries. -->
 ${project.gwtInherits.sortedWith(INHERIT_COMPARATOR).joinToString(separator = "\n") { "  <inherits name=\"$it\" />" }}
@@ -371,6 +376,7 @@ tasks.register('addSource') {
   doLast {
     sourceSets.main.compileClasspath += files(project(':core').sourceSets.main.allJava.srcDirs)
     sourceSets.main.compileClasspath += files("../core/build/generated/sources/annotationProcessor/java/main")
+    sourceSets.main.compileClasspath += files(sourceSets.main.output.resourcesDir)
 ${if (project.hasPlatform(Shared.ID)) "    sourceSets.main.compileClasspath += files(project(':shared').sourceSets.main.allJava.srcDirs)" else ""}
   }
 }


### PR DESCRIPTION
The commit makes project resources visible to the GWT compiler and creates a default package for files that need to be directly published and served with the compiled GWT application.

Both changes are generally useful for game authors, although marginally so. The primary aim is to make more complex JS libraries easier to integrate in liftoff.

The immediate benefits of creating projects with the improved Platform is:
- GWT tools for processing non-java resources (like bundles) can now work with the said resources placed in the resources directory, without having them mixed with the Java sources;
- the contents of the folder _public_html_ placed in the sources (or resources) of the project - is packaged along with the compiled app and placed alongside the compiled module in the `html` dir.
