### PR TITLE
Use modern Material Fullscreen default Android theme

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
@@ -38,12 +38,9 @@ class Android : Platform {
     addCopiedFile(project, "res", "drawable-anydpi-v26", "ic_launcher.xml")
     addCopiedFile(project, "res", "drawable-anydpi-v26", "ic_launcher_foreground.xml")
     addCopiedFile(project, "ic_launcher-web.png")
-
-    // We really can't generate these vector images easily.
-//    addCopiedFile(project, "res", "drawable-anydpi-v26", "ic_launcher.xml")
-//    addCopiedFile(project, "res", "drawable-anydpi-v26", "ic_launcher_foreground.xml")
     addCopiedFile(project, "res", "values", "color.xml")
     addCopiedFile(project, "res", "values", "styles.xml")
+    addCopiedFile(project, "res", "values-v21", "styles.xml")
 
     project.files.add(
       SourceFile(

--- a/src/main/resources/generator/android/res/values-v21/styles.xml
+++ b/src/main/resources/generator/android/res/values-v21/styles.xml
@@ -1,0 +1,5 @@
+<resources>
+    <style name="GdxTheme" parent="android:Theme.Material.Light.NoActionBar.Fullscreen">
+        <item name="android:colorBackground">@color/background</item>
+    </style>
+</resources>

--- a/src/main/resources/generator/android/res/values/color.xml
+++ b/src/main/resources/generator/android/res/values/color.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="ic_background_color">#F5A623FF</color>
+    <color name="background">#FFFFFFFF</color>
 </resources>

--- a/src/main/resources/generator/android/res/values/styles.xml
+++ b/src/main/resources/generator/android/res/values/styles.xml
@@ -1,10 +1,5 @@
 <resources>
-    <style name="GdxTheme" parent="android:Theme">
-    <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:colorBackgroundCacheHint">@null</item>
-        <item name="android:windowAnimationStyle">@android:style/Animation</item>
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowFullscreen">true</item>
+    <style name="GdxTheme" parent="android:Theme.Holo.Light.NoActionBar.Fullscreen">
+        <item name="android:windowBackground">@color/background</item>
     </style>
 </resources>


### PR DESCRIPTION
An issue has been reported on Discord related to the navigation bar getting stuck in some cases on Android 35. The issue is related to the Android theme and can be fixed using a fullscreen Material theme (SDK 21+). It also aligns Liftoff to libGDX tests and improves the looks by default of the app's native Android elements.

@tommyettinger Next libGDX release will bump minSDK to 21, making the `values-v21`s folder unnecessary and its contents should be moved to `values` having a sing `styles.xml` file.