### PR TITLE
Updates to match min API 21

### DIFF
--- a/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
+++ b/src/main/kotlin/gdx/liftoff/data/platforms/Android.kt
@@ -43,7 +43,6 @@ class Android : Platform {
     addCopiedFile(project, "ic_launcher-web.png")
     addCopiedFile(project, "res", "values", "color.xml")
     addCopiedFile(project, "res", "values", "styles.xml")
-    addCopiedFile(project, "res", "values-v21", "styles.xml")
 
     project.files.add(
       SourceFile(

--- a/src/main/resources/generator/android/project.properties
+++ b/src/main/resources/generator/android/project.properties
@@ -11,4 +11,4 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-rules.pro
 
 # Project target.
-target=android-19
+target=android-21

--- a/src/main/resources/generator/android/res/values-v21/styles.xml
+++ b/src/main/resources/generator/android/res/values-v21/styles.xml
@@ -1,5 +1,0 @@
-<resources>
-    <style name="GdxTheme" parent="android:Theme.Material.Light.NoActionBar.Fullscreen">
-        <item name="android:colorBackground">@color/background</item>
-    </style>
-</resources>

--- a/src/main/resources/generator/android/res/values/styles.xml
+++ b/src/main/resources/generator/android/res/values/styles.xml
@@ -1,5 +1,5 @@
 <resources>
-    <style name="GdxTheme" parent="android:Theme.Holo.Light.NoActionBar.Fullscreen">
-        <item name="android:windowBackground">@color/background</item>
+    <style name="GdxTheme" parent="android:Theme.Material.Light.NoActionBar.Fullscreen">
+        <item name="android:colorBackground">@color/background</item>
     </style>
 </resources>


### PR DESCRIPTION
With min Android API 21 we can simplify resources.

Also updated `project.properties` even if I don't know why we needed (I think it used to be on Eclipse long time ago).